### PR TITLE
fix_レスポンシブデザイン対応#スマホ#2

### DIFF
--- a/app/views/body_records/_form.html.erb
+++ b/app/views/body_records/_form.html.erb
@@ -11,7 +11,7 @@
       <%= f.label :weight, "体重", class: "block text-violet-600 text-xs mb-0.5" %>
       <div class="flex items-center">
         <%= f.number_field :weight, step: 0.1, min: 0,
-              class: "w-full border rounded-lg px-2 py-1 text-right text-sm" %>
+              class: "w-full border rounded-lg px-2 py-1 text-right text-sm bg-white text-black" %>
         <span class="ml-1 text-xs text-violet-600">kg</span>
       </div>
       <% if @body_record.errors[:weight].present? %>
@@ -22,7 +22,7 @@
       <%= f.label :body_fat, "体脂肪率", class: "block text-violet-600 text-xs mb-0.5" %>
       <div class="flex items-center">
         <%= f.number_field :body_fat, step: 0.1, min: 0,
-              class: "w-full border rounded-lg px-2 py-1 text-right text-sm" %>
+              class: "w-full border rounded-lg px-2 py-1 text-right text-sm bg-white text-black" %>
         <span class="ml-1 text-xs text-violet-600">%</span>
       </div>
       <% if @body_record.errors[:body_fat].present? %>
@@ -57,7 +57,7 @@
       <label class="relative inline-block text-center
                     border border-violet-600 text-violet-600
                     w-1/3 py-2 rounded hover:bg-violet-50
-                    cursor-pointer mb-1 transition-colors text-xs">
+                    cursor-pointer mb-1 transition-colors text-xs bg-white text-black">
         ファイルを選択
         <%= f.file_field :photo,
               data: { camera_target: "fileInput" },

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -37,7 +37,7 @@
                          text-white focus:outline-none focus:ring-2 focus:ring-white
                          focus:ring-opacity-50" %>
             <div class="flex items-center mt-1 text-black">
-              <%= f.check_box :remember_me, class: "accent-violet-600" %>
+              <%= f.check_box :remember_me, class: "accent-violet-600 bg-white" %>
               <%= f.label :remember_me, "次回から自動的にログインする", class: "text-black" %>
             </div>
           </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -40,7 +40,7 @@
         <%= collection_radio_buttons :profile, :gender,
              Profile.genders.keys, :to_s, :humanize, checked: @profile.gender do |b| %>
           <div class="inline-flex items-center mr-4">
-            <%= b.radio_button(class: "mr-1") %><%= b.label(class: "text-black") %>
+            <%= b.radio_button(class: "mr-1 bg-white") %><%= b.label(class: "text-black") %>
           </div>
         <% end %>
       </div>
@@ -51,7 +51,7 @@
              Profile.training_intensities.keys, :to_s, :humanize,
              checked: @profile.training_intensity do |b| %>
           <div class="inline-flex items-center mr-4">
-            <%= b.radio_button(class: "mr-1") %><%= b.label(class: "text-black") %>
+            <%= b.radio_button(class: "mr-1 bg-white") %><%= b.label(class: "text-black") %>
           </div>
         <% end %>
       </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -37,7 +37,7 @@
       <% end %>
     </div>
     <!-- 2段階認証ボタン（LINE連携ボタンと同じ幅） -->
-    <%= link_to users_two_factor_settings_path, class: "flex items-center justify-center w-1/3 px-4 py-2 bg-gradient-to-r from-blue-500 to-indigo-600 text-white font-semibold text-sm rounded-full shadow-md hover:from-blue-600 hover:to-indigo-700 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 transition-all duration-200 mt-6" do %>
+    <%= link_to users_two_factor_settings_path, class: "flex items-center justify-center w-1/2 px-4 py-2 bg-gradient-to-r from-blue-500 to-indigo-600 text-white font-semibold text-sm rounded-full shadow-md hover:from-blue-600 hover:to-indigo-700 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 transition-all duration-200 mt-6" do %>
       <svg class="w-5 h-5 mr-1 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" d="M16 10V7a4 4 0 10-8 0v3m12 0a2 2 0 012 2v6a2 2 0 01-2 2H6a2 2 0 01-2-2v-6a2 2 0 012-2h12zm-6 4v2m0 0h.01"/>
       </svg>

--- a/app/views/users/two_factor_settings/show.html.erb
+++ b/app/views/users/two_factor_settings/show.html.erb
@@ -25,7 +25,7 @@
       </div>
       <div class="mb-4 text-center">
         <span class="text-xs text-gray-500">手動入力用シークレット</span>
-        <div class="font-mono text-base text-blue-700 tracking-widest bg-gray-100 rounded px-2 py-1 inline-block mt-1 shadow-sm select-all"><%= current_user.otp_secret %></div>
+        <div class="font-mono text-xs text-blue-700 tracking-widest bg-gray-100 rounded px-2 py-1 inline-block mt-1 shadow-sm select-all"><%= current_user.otp_secret %></div>
       </div>
       <%= form_with url: users_two_factor_settings_path, method: :patch, class: "space-y-5" do |f| %>
         <div>


### PR DESCRIPTION
## 内容
スマホ(iphone)のレスポンシブデザイン対応#2

・記録へ入力・編集のフォーム内の色を白、文字を黒に設定
・マイページ編集のラジアルボタン内を白に変更
・マイページの２要素認証ボタン幅変更
・2要素認証の手動入力用シークレット文字サイズ変更
・ログインの自動ログインのチェックボックス内を白に変更
