### PR TITLE
fix-ビルド順序を修正してTailwind CSSが正しく生成されるように改善

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -4,11 +4,15 @@
 namespace :assets do
   desc "Build CSS and JS before precompiling assets"
   task :build do
-    puts "Building CSS with PostCSS..."
-    sh "yarn build:css"
+    # 重要: JSを先にビルドし、その後CSSをビルドする
+    # esbuildがMaterial Icons CSSをapplication.cssとして出力するが、
+    # 後からPostCSSでTailwind CSSを上書きすることで正しいCSSを確保する
 
     puts "Building JS with esbuild..."
     sh "yarn build"
+
+    puts "Building CSS with PostCSS..."
+    sh "yarn build:css"
   end
 end
 


### PR DESCRIPTION
## 問題の原因
esbuildがapp/javascript/application.jsから
Material Icons CSSをインポートし、application.cssとして
110.8KBのファイルを出力していた。

その後PostCSSでTailwind CSSをビルドしようとしていたが、
実行順序が間違っていたため、esbuildが生成したMaterial Icons CSS
がそのまま本番環境にデプロイされていた。

## 実施した修正
lib/tasks/assets.rakeの実行順序を変更:
1. yarn build (esbuild) を先に実行
2. yarn build:css (PostCSS) を後に実行

これによりesbuildが出力したCSSファイルを
PostCSSが正しくTailwind CSSで上書きする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)