### PR TITLE
refactor-BodyRecords機能のService層構築とテスト追加

### DIFF
--- a/app/forms/body_record_form.rb
+++ b/app/forms/body_record_form.rb
@@ -1,0 +1,38 @@
+class BodyRecordForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :recorded_at
+  attribute :weight, :float
+  attribute :body_fat, :float
+  attribute :fat_mass, :float
+  attribute :photo
+
+  validates :weight, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 300 }, allow_nil: true
+  validates :body_fat, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }, allow_nil: true
+  validates :fat_mass, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+
+  def initialize(attributes = {})
+    # recorded_at を DateParsingService でパース
+    if attributes[:recorded_at].present?
+      attributes[:recorded_at] = DateParsingService.parse_to_beginning_of_day(attributes[:recorded_at])
+    end
+    super(attributes)
+  end
+
+  # BodyRecord に保存するための属性ハッシュを返す
+  # photo は別途処理するため除外
+  def body_record_attributes
+    {
+      recorded_at: recorded_at,
+      weight: weight,
+      body_fat: body_fat,
+      fat_mass: fat_mass
+    }
+  end
+
+  # photo が添付されているかを判定
+  def photo_attached?
+    photo.present?
+  end
+end

--- a/app/services/body_record_finder.rb
+++ b/app/services/body_record_finder.rb
@@ -1,0 +1,49 @@
+class BodyRecordFinder
+  def initialize(user)
+    @user = user
+  end
+
+  # カレンダー表示用: 月のカレンダー範囲内のレコードを取得
+  # @param selected_date [Date, String] 選択された日付
+  # @return [Hash] { body_records: ActiveRecord::Relation, days_with_records: Array<Date>, date_range: Range }
+  def find_for_calendar(selected_date)
+    date = DateParsingService.parse_to_date(selected_date)
+
+    # 月のカレンダー範囲(週の開始と終了を含む)
+    date_range = (
+      date.beginning_of_month.beginning_of_week(:sunday) ..
+      date.end_of_month.end_of_week(:sunday)
+    )
+
+    # DB検索用のTime範囲
+    time_range = date_range.first.beginning_of_day .. date_range.last.end_of_day
+
+    body_records = @user.body_records.where(recorded_at: time_range)
+    days_with_records = body_records.pluck(:recorded_at).map(&:to_date)
+
+    {
+      body_records: body_records,
+      days_with_records: days_with_records,
+      date_range: date_range
+    }
+  end
+
+  # 特定日のレコードを取得(なければ新規作成して返す)
+  # @param date [Date, String] 取得したい日付
+  # @return [BodyRecord] 既存レコード or 新規インスタンス
+  def find_or_build_for_date(date)
+    parsed_date = DateParsingService.parse_to_date(date)
+    time_range = parsed_date.all_day
+
+    @user.body_records.where(recorded_at: time_range).first ||
+      @user.body_records.new(recorded_at: parsed_date)
+  end
+
+  # 特定日のレコードをfind_or_initialize_by (保存前の状態)
+  # @param date [Date, String] 取得したい日付
+  # @return [BodyRecord] 既存レコード or 新規インスタンス(未保存)
+  def find_or_initialize_for_date(date)
+    recorded_at = DateParsingService.parse_to_beginning_of_day(date)
+    @user.body_records.find_or_initialize_by(recorded_at: recorded_at)
+  end
+end

--- a/app/services/date_parsing_service.rb
+++ b/app/services/date_parsing_service.rb
@@ -1,0 +1,37 @@
+class DateParsingService
+  class << self
+    # 文字列、Date、Time、DateTime から Date オブジェクトを返す
+    # パース失敗時はデフォルト値を返す(デフォルトは今日の日付)
+    def parse_to_date(value, default: Date.current)
+      return default if value.blank?
+
+      case value
+      when Time, DateTime
+        Date.new(value.year, value.month, value.day)
+      when Date
+        value
+      when String
+        Date.parse(value)
+      else
+        default
+      end
+    rescue ArgumentError, TypeError
+      default
+    end
+
+    # Time の beginning_of_day を返す
+    # 主に DB 検索用(recorded_at に保存する形式)
+    def parse_to_beginning_of_day(value, default: Date.current)
+      date = parse_to_date(value, default: default)
+      date.beginning_of_day
+    end
+
+    # 日付範囲をパースして Time の範囲を返す
+    # DB検索用
+    def parse_date_range(start_date, end_date)
+      start_time = parse_to_beginning_of_day(start_date)
+      end_time = parse_to_date(end_date).end_of_day
+      start_time..end_time
+    end
+  end
+end

--- a/spec/forms/body_record_form_spec.rb
+++ b/spec/forms/body_record_form_spec.rb
@@ -1,0 +1,170 @@
+require 'rails_helper'
+
+RSpec.describe BodyRecordForm do
+  describe 'バリデーション' do
+    context '正常系' do
+      it '有効な値の場合は valid' do
+        form = described_class.new(
+          recorded_at: '2025-01-15',
+          weight: 70.5,
+          body_fat: 18.3,
+          fat_mass: 12.9
+        )
+
+        expect(form).to be_valid
+      end
+
+      it 'weight が nil でも valid' do
+        form = described_class.new(
+          recorded_at: '2025-01-15',
+          weight: nil,
+          body_fat: 18.3
+        )
+
+        expect(form).to be_valid
+      end
+
+      it 'body_fat が nil でも valid' do
+        form = described_class.new(
+          recorded_at: '2025-01-15',
+          weight: 70.5,
+          body_fat: nil
+        )
+
+        expect(form).to be_valid
+      end
+    end
+
+    context 'weight のバリデーション' do
+      it 'weight が 0 未満の場合は invalid' do
+        form = described_class.new(weight: -1)
+        expect(form).not_to be_valid
+        expect(form.errors[:weight]).to be_present
+      end
+
+      it 'weight が 300 を超える場合は invalid' do
+        form = described_class.new(weight: 301)
+        expect(form).not_to be_valid
+        expect(form.errors[:weight]).to be_present
+      end
+
+      it 'weight が 0 の場合は valid' do
+        form = described_class.new(weight: 0)
+        expect(form).to be_valid
+      end
+
+      it 'weight が 300 の場合は valid' do
+        form = described_class.new(weight: 300)
+        expect(form).to be_valid
+      end
+    end
+
+    context 'body_fat のバリデーション' do
+      it 'body_fat が 0 未満の場合は invalid' do
+        form = described_class.new(body_fat: -1)
+        expect(form).not_to be_valid
+        expect(form.errors[:body_fat]).to be_present
+      end
+
+      it 'body_fat が 100 を超える場合は invalid' do
+        form = described_class.new(body_fat: 101)
+        expect(form).not_to be_valid
+        expect(form.errors[:body_fat]).to be_present
+      end
+
+      it 'body_fat が 0 の場合は valid' do
+        form = described_class.new(body_fat: 0)
+        expect(form).to be_valid
+      end
+
+      it 'body_fat が 100 の場合は valid' do
+        form = described_class.new(body_fat: 100)
+        expect(form).to be_valid
+      end
+    end
+
+    context 'fat_mass のバリデーション' do
+      it 'fat_mass が 0 未満の場合は invalid' do
+        form = described_class.new(fat_mass: -1)
+        expect(form).not_to be_valid
+        expect(form.errors[:fat_mass]).to be_present
+      end
+
+      it 'fat_mass が 0 の場合は valid' do
+        form = described_class.new(fat_mass: 0)
+        expect(form).to be_valid
+      end
+
+      it 'fat_mass が nil の場合は valid' do
+        form = described_class.new(fat_mass: nil)
+        expect(form).to be_valid
+      end
+    end
+  end
+
+  describe '#initialize' do
+    it '文字列の日付を recorded_at に指定すると beginning_of_day に変換される' do
+      form = described_class.new(recorded_at: '2025-01-15')
+
+      expect(form.recorded_at).to eq(Date.new(2025, 1, 15).beginning_of_day)
+    end
+
+    it 'Date オブジェクトを recorded_at に指定すると beginning_of_day に変換される' do
+      form = described_class.new(recorded_at: Date.new(2025, 1, 15))
+
+      expect(form.recorded_at).to eq(Date.new(2025, 1, 15).beginning_of_day)
+    end
+
+    it 'recorded_at が nil の場合は nil のまま' do
+      form = described_class.new(recorded_at: nil)
+
+      expect(form.recorded_at).to be_nil
+    end
+
+    it '不正な日付文字列の場合はデフォルト値の beginning_of_day' do
+      form = described_class.new(recorded_at: 'invalid')
+
+      expect(form.recorded_at).to eq(Date.current.beginning_of_day)
+    end
+  end
+
+  describe '#body_record_attributes' do
+    it 'BodyRecord に保存する属性を返す(photo 以外)' do
+      recorded_at = Date.new(2025, 1, 15).beginning_of_day
+      form = described_class.new(
+        recorded_at: recorded_at,
+        weight: 70.5,
+        body_fat: 18.3,
+        fat_mass: 12.9,
+        photo: 'dummy_photo'
+      )
+
+      attributes = form.body_record_attributes
+
+      expect(attributes).to eq({
+        recorded_at: recorded_at,
+        weight: 70.5,
+        body_fat: 18.3,
+        fat_mass: 12.9
+      })
+      expect(attributes).not_to have_key(:photo)
+    end
+  end
+
+  describe '#photo_attached?' do
+    it 'photo が存在する場合は true' do
+      form = described_class.new(photo: 'dummy_photo')
+      expect(form.photo_attached?).to be true
+    end
+
+    it 'photo が nil の場合は false' do
+      form = described_class.new(photo: nil)
+      expect(form.photo_attached?).to be false
+    end
+
+    it 'photo が空文字の場合は false' do
+      form = described_class.new(photo: '')
+      expect(form.photo_attached?).to be false
+    end
+  end
+end

--- a/spec/models/body_record_spec.rb
+++ b/spec/models/body_record_spec.rb
@@ -1,35 +1,99 @@
 require 'rails_helper'
 
-# 全テスト一時停止中（必要なものだけ有効化してください）
 RSpec.describe BodyRecord, type: :model do
+  describe 'アソシエーション' do
+    it { should belong_to(:user) }
+  end
+
   describe 'バリデーション' do
-    it 'weightが0以上300以下の数値であること' do
-      record = BodyRecord.new(weight: -1)
-      record.valid?
-      expect(record.errors[:weight]).to be_present
-      record = BodyRecord.new(weight: 301)
-      record.valid?
-      expect(record.errors[:weight]).to be_present
-      record = BodyRecord.new(weight: 150)
-      record.valid?
-      expect(record.errors[:weight]).to be_blank
+    context 'weight' do
+      it '0以上300以下の数値であること' do
+        should validate_numericality_of(:weight)
+          .is_greater_than_or_equal_to(0)
+          .is_less_than_or_equal_to(300)
+      end
+
+      it 'nil の場合は valid' do
+        record = build(:body_record, weight: nil)
+        expect(record).to be_valid
+      end
+
+      it '0 の場合は valid' do
+        record = build(:body_record, weight: 0)
+        expect(record).to be_valid
+      end
+
+      it '300 の場合は valid' do
+        record = build(:body_record, weight: 300)
+        expect(record).to be_valid
+      end
+
+      it '-1 の場合は invalid' do
+        record = build(:body_record, weight: -1)
+        expect(record).not_to be_valid
+        expect(record.errors[:weight]).to be_present
+      end
+
+      it '301 の場合は invalid' do
+        record = build(:body_record, weight: 301)
+        expect(record).not_to be_valid
+        expect(record.errors[:weight]).to be_present
+      end
     end
 
-    it 'body_fatが0以上100以下の数値であること' do
-      record = BodyRecord.new(body_fat: -1)
-      record.valid?
-      expect(record.errors[:body_fat]).to be_present
-      record = BodyRecord.new(body_fat: 101)
-      record.valid?
-      expect(record.errors[:body_fat]).to be_present
-      record = BodyRecord.new(body_fat: 50)
-      record.valid?
-      expect(record.errors[:body_fat]).to be_blank
+    context 'body_fat' do
+      it '0以上100以下の数値であること' do
+        should validate_numericality_of(:body_fat)
+          .is_greater_than_or_equal_to(0)
+          .is_less_than_or_equal_to(100)
+      end
+
+      it 'nil の場合は valid' do
+        record = build(:body_record, body_fat: nil)
+        expect(record).to be_valid
+      end
+
+      it '0 の場合は valid' do
+        record = build(:body_record, body_fat: 0)
+        expect(record).to be_valid
+      end
+
+      it '100 の場合は valid' do
+        record = build(:body_record, body_fat: 100)
+        expect(record).to be_valid
+      end
+
+      it '-1 の場合は invalid' do
+        record = build(:body_record, body_fat: -1)
+        expect(record).not_to be_valid
+        expect(record.errors[:body_fat]).to be_present
+      end
+
+      it '101 の場合は invalid' do
+        record = build(:body_record, body_fat: 101)
+        expect(record).not_to be_valid
+        expect(record.errors[:body_fat]).to be_present
+      end
     end
   end
 
-  describe 'アソシエーション' do
-    it { should belong_to(:user) }
-    it { should have_one_attached(:photo) }
+  describe 'ActiveStorage' do
+    it 'photo が添付できること' do
+      record = create(:body_record)
+      expect(record.photo).to be_an_instance_of(ActiveStorage::Attached::One)
+    end
+  end
+
+  describe 'データ作成' do
+    it 'Factory Bot で正常に作成できること' do
+      record = build(:body_record)
+      expect(record).to be_valid
+    end
+
+    it '保存すると created_at と updated_at が設定されること' do
+      record = create(:body_record)
+      expect(record.created_at).to be_present
+      expect(record.updated_at).to be_present
+    end
   end
 end

--- a/spec/services/body_record_finder_spec.rb
+++ b/spec/services/body_record_finder_spec.rb
@@ -1,0 +1,164 @@
+require 'rails_helper'
+
+RSpec.describe BodyRecordFinder do
+  let(:user) { create(:user) }
+  let(:finder) { described_class.new(user) }
+
+  describe '#find_for_calendar' do
+    let(:selected_date) { Date.new(2025, 1, 15) } # 2025年1月15日(水)
+
+    context 'レコードが存在する場合' do
+      let!(:record1) { create(:body_record, user: user, recorded_at: Date.new(2025, 1, 1).beginning_of_day, weight: 70.0) }
+      let!(:record2) { create(:body_record, user: user, recorded_at: Date.new(2025, 1, 15).beginning_of_day, weight: 71.0) }
+      let!(:record3) { create(:body_record, user: user, recorded_at: Date.new(2025, 1, 31).beginning_of_day, weight: 72.0) }
+      # 範囲外のレコード(2月2日以降)
+      let!(:record_outside) { create(:body_record, user: user, recorded_at: Date.new(2025, 2, 5).beginning_of_day, weight: 73.0) }
+
+      it 'カレンダー範囲内のレコードを返す' do
+        result = finder.find_for_calendar(selected_date)
+
+        expect(result[:body_records]).to include(record1, record2, record3)
+        expect(result[:body_records]).not_to include(record_outside)
+      end
+
+      it 'レコードが存在する日付のリストを返す' do
+        result = finder.find_for_calendar(selected_date)
+
+        expect(result[:days_with_records]).to contain_exactly(
+          Date.new(2025, 1, 1),
+          Date.new(2025, 1, 15),
+          Date.new(2025, 1, 31)
+        )
+      end
+
+      it 'カレンダーの日付範囲を返す' do
+        result = finder.find_for_calendar(selected_date)
+
+        # 2025年1月のカレンダー範囲
+        # beginning_of_month.beginning_of_week(:sunday) = 2024/12/29(日)
+        # end_of_month.end_of_week(:sunday) = 2025/2/1(土)
+        expect(result[:date_range].first).to eq(Date.new(2024, 12, 29))
+        expect(result[:date_range].last).to eq(Date.new(2025, 2, 1))
+      end
+    end
+
+    context 'レコードが存在しない場合' do
+      it '空の配列を返す' do
+        result = finder.find_for_calendar(selected_date)
+
+        expect(result[:body_records]).to be_empty
+        expect(result[:days_with_records]).to be_empty
+      end
+
+      it 'カレンダーの日付範囲は返す' do
+        result = finder.find_for_calendar(selected_date)
+
+        expect(result[:date_range]).not_to be_nil
+        expect(result[:date_range].first).to eq(Date.new(2024, 12, 29))
+        expect(result[:date_range].last).to eq(Date.new(2025, 2, 1))
+      end
+    end
+
+    context '文字列の日付を渡した場合' do
+      it '正しくパースしてレコードを取得する' do
+        create(:body_record, user: user, recorded_at: Date.new(2025, 1, 15).beginning_of_day)
+
+        result = finder.find_for_calendar('2025-01-15')
+
+        expect(result[:body_records].count).to eq(1)
+      end
+    end
+
+    context '他のユーザーのレコードが存在する場合' do
+      let(:other_user) { create(:user) }
+      let!(:other_record) { create(:body_record, user: other_user, recorded_at: Date.new(2025, 1, 15).beginning_of_day) }
+
+      it '他のユーザーのレコードは含まれない' do
+        result = finder.find_for_calendar(selected_date)
+
+        expect(result[:body_records]).not_to include(other_record)
+      end
+    end
+  end
+
+  describe '#find_or_build_for_date' do
+    let(:target_date) { Date.new(2025, 1, 15) }
+
+    context 'レコードが存在する場合' do
+      let!(:existing_record) { create(:body_record, user: user, recorded_at: target_date.beginning_of_day, weight: 70.0) }
+
+      it '既存のレコードを返す' do
+        result = finder.find_or_build_for_date(target_date)
+
+        expect(result).to eq(existing_record)
+        expect(result.persisted?).to be true
+      end
+    end
+
+    context 'レコードが存在しない場合' do
+      it '新規レコードを構築して返す(未保存)' do
+        result = finder.find_or_build_for_date(target_date)
+
+        expect(result).to be_a(BodyRecord)
+        expect(result.persisted?).to be false
+        expect(result.user).to eq(user)
+        expect(result.recorded_at.to_date).to eq(target_date)
+      end
+    end
+
+    context '文字列の日付を渡した場合' do
+      it '正しくパースして検索する' do
+        create(:body_record, user: user, recorded_at: target_date.beginning_of_day)
+
+        result = finder.find_or_build_for_date('2025-01-15')
+
+        expect(result.persisted?).to be true
+        expect(result.recorded_at.to_date).to eq(target_date)
+      end
+    end
+  end
+
+  describe '#find_or_initialize_for_date' do
+    let(:target_date) { Date.new(2025, 1, 15) }
+
+    context 'レコードが存在する場合' do
+      let!(:existing_record) { create(:body_record, user: user, recorded_at: target_date.beginning_of_day, weight: 70.0) }
+
+      it '既存のレコードを返す' do
+        result = finder.find_or_initialize_for_date(target_date)
+
+        expect(result).to eq(existing_record)
+        expect(result.persisted?).to be true
+      end
+    end
+
+    context 'レコードが存在しない場合' do
+      it '新規レコードを初期化して返す(未保存)' do
+        result = finder.find_or_initialize_for_date(target_date)
+
+        expect(result).to be_a(BodyRecord)
+        expect(result.persisted?).to be false
+        expect(result.user).to eq(user)
+        expect(result.recorded_at).to eq(target_date.beginning_of_day)
+      end
+    end
+
+    context '文字列の日付を渡した場合' do
+      it '正しくパースして初期化する' do
+        result = finder.find_or_initialize_for_date('2025-01-15')
+
+        expect(result.persisted?).to be false
+        expect(result.recorded_at).to eq(target_date.beginning_of_day)
+      end
+    end
+
+    context '不正な日付文字列を渡した場合' do
+      it 'デフォルト値(今日)で初期化する' do
+        result = finder.find_or_initialize_for_date('invalid')
+
+        expect(result.persisted?).to be false
+        expect(result.recorded_at).to eq(Date.current.beginning_of_day)
+      end
+    end
+  end
+end

--- a/spec/services/date_parsing_service_spec.rb
+++ b/spec/services/date_parsing_service_spec.rb
@@ -1,0 +1,117 @@
+require 'rails_helper'
+
+RSpec.describe DateParsingService do
+  describe '.parse_to_date' do
+    context '正常系' do
+      it 'Date オブジェクトをそのまま返す' do
+        date = Date.new(2025, 1, 15)
+        expect(described_class.parse_to_date(date)).to eq(date)
+      end
+
+      it 'Time オブジェクトを Date に変換する' do
+        time = Time.zone.parse('2025-01-15 10:30:00')
+        expect(described_class.parse_to_date(time)).to eq(Date.new(2025, 1, 15))
+      end
+
+      it 'DateTime オブジェクトを Date に変換する' do
+        datetime = DateTime.new(2025, 1, 15, 10, 30, 0)
+        expect(described_class.parse_to_date(datetime)).to eq(Date.new(2025, 1, 15))
+      end
+
+      it '文字列(YYYY-MM-DD形式)を Date に変換する' do
+        expect(described_class.parse_to_date('2025-01-15')).to eq(Date.new(2025, 1, 15))
+      end
+
+      it '文字列(YYYY/MM/DD形式)を Date に変換する' do
+        expect(described_class.parse_to_date('2025/01/15')).to eq(Date.new(2025, 1, 15))
+      end
+    end
+
+    context '異常系' do
+      it 'nil の場合はデフォルト値(今日の日付)を返す' do
+        expect(described_class.parse_to_date(nil)).to eq(Date.current)
+      end
+
+      it '空文字の場合はデフォルト値を返す' do
+        expect(described_class.parse_to_date('')).to eq(Date.current)
+      end
+
+      it '不正な文字列の場合はデフォルト値を返す' do
+        expect(described_class.parse_to_date('invalid')).to eq(Date.current)
+      end
+
+      it '数値の場合はデフォルト値を返す' do
+        expect(described_class.parse_to_date(12345)).to eq(Date.current)
+      end
+
+      it 'カスタムデフォルト値を指定できる' do
+        custom_default = Date.new(2025, 12, 31)
+        expect(described_class.parse_to_date(nil, default: custom_default)).to eq(custom_default)
+      end
+    end
+  end
+
+  describe '.parse_to_beginning_of_day' do
+    it 'Date を beginning_of_day に変換する' do
+      date = Date.new(2025, 1, 15)
+      expected = date.beginning_of_day
+      expect(described_class.parse_to_beginning_of_day(date)).to eq(expected)
+    end
+
+    it '文字列を beginning_of_day に変換する' do
+      expected = Date.new(2025, 1, 15).beginning_of_day
+      expect(described_class.parse_to_beginning_of_day('2025-01-15')).to eq(expected)
+    end
+
+    it 'Time を beginning_of_day に変換する' do
+      time = Time.zone.parse('2025-01-15 15:30:45')
+      expected = Date.new(2025, 1, 15).beginning_of_day
+      expect(described_class.parse_to_beginning_of_day(time)).to eq(expected)
+    end
+
+    it '不正な値の場合はデフォルト値の beginning_of_day を返す' do
+      expect(described_class.parse_to_beginning_of_day('invalid')).to eq(Date.current.beginning_of_day)
+    end
+
+    it 'カスタムデフォルト値を指定できる' do
+      custom_default = Date.new(2025, 12, 31)
+      expected = custom_default.beginning_of_day
+      expect(described_class.parse_to_beginning_of_day(nil, default: custom_default)).to eq(expected)
+    end
+  end
+
+  describe '.parse_date_range' do
+    it '開始日と終了日から Time の範囲を返す' do
+      start_date = '2025-01-01'
+      end_date = '2025-01-31'
+
+      expected_start = Date.new(2025, 1, 1).beginning_of_day
+      expected_end = Date.new(2025, 1, 31).end_of_day
+
+      result = described_class.parse_date_range(start_date, end_date)
+
+      expect(result.begin).to eq(expected_start)
+      expect(result.end).to eq(expected_end)
+    end
+
+    it 'Date オブジェクトでも動作する' do
+      start_date = Date.new(2025, 1, 1)
+      end_date = Date.new(2025, 1, 31)
+
+      expected_start = start_date.beginning_of_day
+      expected_end = end_date.end_of_day
+
+      result = described_class.parse_date_range(start_date, end_date)
+
+      expect(result.begin).to eq(expected_start)
+      expect(result.end).to eq(expected_end)
+    end
+
+    it '不正な値の場合はデフォルト値で範囲を作成する' do
+      result = described_class.parse_date_range('invalid', 'invalid')
+
+      expect(result.begin).to eq(Date.current.beginning_of_day)
+      expect(result.end).to eq(Date.current.end_of_day)
+    end
+  end
+end


### PR DESCRIPTION
## チーム2のリファクタリングタスク完了

### 1. DateParsingService 作成
- 日付パースロジックを共通化
- parse_to_date: 文字列/Date/Time/DateTimeをDateに変換
- parse_to_beginning_of_day: DB検索用のbeginning_of_dayを返す
- parse_date_range: 日付範囲をDB検索用のTime範囲に変換
- テスト: 18個のテストケースが全て通過

### 2. BodyRecordFinder 作成
- レコード検索ロジックをControllerから抽出
- find_for_calendar: 月のカレンダー範囲内のレコードを取得
- find_or_build_for_date: 特定日のレコードを取得(なければ新規作成)
- find_or_initialize_for_date: find_or_initialize_byをラップ
- テスト: 14個のテストケースが全て通過

### 3. BodyRecordForm Object 作成
- バリデーションロジックをForm Objectに集約
- ActiveModel::Modelを使用したForm Object
- weight, body_fat, fat_massのバリデーション
- 日付パースを初期化時に自動実行
- テスト: 22個のテストケースが全て通過

### 4. BodyRecord モデルのテスト強化
- バリデーションテストを充実化
- shoulda-matchersを使用したテスト
- Factory Botを使用したテスト
- ActiveStorageのテスト追加
- テスト: 16個のテストケースが全て通過

## 品質チェック
- 全テスト: 86個のテストケースが全て通過 ✓
- RuboCop: 違反ゼロ ✓

## 完了条件達成
- ✅ DateParsingService: 日付処理が一元化、エラーハンドリング統一
- ✅ BodyRecordForm: バリデーションロジック集約
- ✅ BodyRecordFinder: Service のテストカバレッジ90%以上
- ✅ BodyRecord モデル: テストカバレッジ90%以上

🤖 Generated with [Claude Code](https://claude.com/claude-code)